### PR TITLE
openapi.yml: use api.ssoready.com as the base url

### DIFF
--- a/fern/openapi.yml
+++ b/fern/openapi.yml
@@ -6,7 +6,7 @@ info:
   title: SSOReadyService API
   version: 0.0.1
 servers:
-  - url: https://api.dev-ucarion.ssoready-nonprod.com
+  - url: https://api.ssoready.com
 paths:
   /v1/saml/redeem:
     post:


### PR DESCRIPTION
This PR has us use the production release of SSOReady as the base URL for SDKs.