### PR TITLE
docs: quickstart: use camel case for properties

### DIFF
--- a/fern/pages/quickstart.mdx
+++ b/fern/pages/quickstart.mdx
@@ -58,10 +58,10 @@ your tech stack.
 curl https://api.ssoready.com/v1/saml/redirect \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ssoready_sk_..." \
-  -d '{ "organization_external_id": "..." }'
+  -d '{ "organizationExternalId": "..." }'
 ```
 
-That code sample requires an API Key (`ssoready_sk_...`) and an `organization_external_id`. How you get those is covered
+That code sample requires an API Key (`ssoready_sk_...`) and an `organizationExternalId`. How you get those is covered
 in [Setting up SSOReady](#setting-up-ssoready) later on this page.
 
 ## Handling SAML logins
@@ -82,15 +82,15 @@ From your backend, you'll exchange that access code for a user's details:
 curl https://api.ssoready.com/v1/saml/redeem \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ssoready_sk_..." \
-  -d '{ "saml_access_code": "saml_access_code_..." }'
+  -d '{ "samlAccessCode": "saml_access_code_..." }'
 ```
 
-The response will include the user's `email` as well as the SSOReady `organization_id` and `organization_external_id`
+The response will include the user's `email` as well as the SSOReady `organizationId` and `organizationExternalId`
 they belong to. It's your responsibility to then log the user in with that given email and organization using whatever
 mechanism your tech stack uses.
 
-How you tell us about your desired "SSOReady callback page", as well as what `organization_id` and
-`organization_external_id` mean, is covered in [Setting up SSOReady](#setting-up-ssoready) below.
+How you tell us about your desired "SSOReady callback page", as well as what `organizationId` and
+`organizationExternalId` mean, is covered in [Setting up SSOReady](#setting-up-ssoready) below.
 
 # Setting up SSOReady
 
@@ -98,7 +98,7 @@ In [Code implementation](#code-implementation), there were three missing pieces 
 
 1. **Where does the SSOReady callback page get configured?** That information lives on [environments](#creating-environments).
 2. **Where do I get an API key?** You create [an API key](#creating-api-keys) scoped to an environment.
-3. **How do I get `organization_external_id`?** You create [an organization](#creating-organizations) in an environment,
+3. **How do I get `organizationExternalId`?** You create [an organization](#creating-organizations) in an environment,
 where you can choose an external ID convenient for you.
 
 This section will step you through how you'll do all of this setup in SSOReady's webapp. As a prerequisite step, you'll
@@ -130,7 +130,7 @@ have a concept that closely matches an SSOReady organization -- usually, this is
 "company", or something similar. When creating an SSOReady organization, use your product's counterpart to an
 organization ID as the external ID.
 
-You'll provide the external ID as the `organization_external_id` in ["Initiating SAML
+You'll provide the external ID as the `organizationExternalId` in ["Initiating SAML
 logins"](#initiating-saml-logins). The external ID is returned to you when ["Redeeming SAML
 logins"](#redeeming-saml-logins).
 * A set of *domains*. If you expect Apple's employees will log in to your product from `@apple.com` and `@shazam.com`
@@ -147,7 +147,7 @@ creates a new SAML connection. Beyond the SAML-related settings covered in ["Onb
 customers"](#onboarding-customers), SAML connections have one setting of note: whether they are *primary*.
 
 Each organization has up to one primary SAML connection. In ["Initiating SAML logins"](#initiating-saml-logins), you
-provide an `organization_external_id`. SSOReady will use that organization's primary SAML connection to initiate the
+provide an `organizationExternalId`. SSOReady will use that organization's primary SAML connection to initiate the
 login.
 
 # Onboarding customers


### PR DESCRIPTION
Though the API accepts both, it outputs in camel-case and the OpenAPI spec only mentions camel-case for input. In the interest of consistency and likelihood of "find in page" behaving as users would want, move all examples to use camel case.