### PR TITLE
Document differing behavior between v4 and beta of next-auth

### DIFF
--- a/fern/pages/saml-oauth.mdx
+++ b/fern/pages/saml-oauth.mdx
@@ -218,7 +218,7 @@ From there, whenever you want to log a user in, you run:
 ```typescript
 import { signIn } from "next-auth/react"
 
-signIn("ssoready", undefined, { organizationExternalId: "..." })
+signIn("ssoready-saml", undefined, { organizationExternalId: "..." })
 ```
 
 The SSOReady OAuth provider will give you profiles containing an `email`, `organizationId`, and


### PR DESCRIPTION
The current and upcoming versions of NextAuth.js require different settings. This PR covers those differences, and changes the suggested settings so that the differences in e.g. callback URLs are removed.