### PR TITLE
chore: upgrade Java SDK to `2.3.0`

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -62,15 +62,6 @@ groups:
           reference-url: "https://ssoready.com/docs"
         output:
           location: maven
-          coordinate: com.ssoready:ssoready-java
-          username: ${MAVEN_USERNAME}
-          password: ${MAVEN_PASSWORD}
-          signature:
-            keyId: ${MAVEN_CENTRAL_SECRET_KEY_KEY_ID}
-            password: ${MAVEN_CENTRAL_SECRET_KEY_PASSWORD}
-            secretKey: ${MAVEN_CENTRAL_SECRET_KEY}
-        output:
-          location: maven
           coordinate: com.ssoready:ssoready-java-sdk
           username: ${MAVEN_USERNAME}
           password: ${MAVEN_PASSWORD}

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -54,7 +54,21 @@ groups:
   java-sdk:
     generators:
       - name: fernapi/fern-java-sdk
-        version: 2.2.0
+        version: 2.3.0
+        publish-metadata:
+          author: "SSOReady"
+          email: "founders@ssoready.com"
+          package-description: "The official Java library for SSOReady"
+          reference-url: "https://ssoready.com/docs"
+        output:
+          location: maven
+          coordinate: com.cohere:cohere-java
+          username: ${MAVEN_USERNAME}
+          password: ${MAVEN_PASSWORD}
+          signature:
+            keyId: ${MAVEN_CENTRAL_SECRET_KEY_KEY_ID}
+            password: ${MAVEN_CENTRAL_SECRET_KEY_PASSWORD}
+            secretKey: ${MAVEN_CENTRAL_SECRET_KEY}
         output:
           location: maven
           coordinate: com.ssoready:ssoready-java-sdk

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -62,7 +62,7 @@ groups:
           reference-url: "https://ssoready.com/docs"
         output:
           location: maven
-          coordinate: com.cohere:cohere-java
+          coordinate: com.ssoready:ssoready-java
           username: ${MAVEN_USERNAME}
           password: ${MAVEN_PASSWORD}
           signature:


### PR DESCRIPTION
As part of this upgrade, Java publishing to maven central should now work.